### PR TITLE
externalise ExecutionContext and some doco

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,11 @@ Currently it partially supports the following Mandrill APIs:
   - users
   - messages
   - subaccounts
+
+## Getting Started
+
+When using sbt add the following to your build file:
+
+```scala
+libraryDependencies += "io.skyfii" %% "skyfii-mandrill" % "0.0.2"
+```

--- a/README.md
+++ b/README.md
@@ -17,3 +17,15 @@ When using sbt add the following to your build file:
 ```scala
 libraryDependencies += "io.skyfii" %% "skyfii-mandrill" % "0.0.2"
 ```
+
+### Test your API key
+
+In an SBT console:
+
+scala>  import scala.concurrent._
+scala>  import scala.concurrent.duration._
+scala>  import scala.concurrent.ExecutionContext.Implicits.global
+scala>  import io.skyfii.mandrill.service._
+scala>  val api = new MandrillApiV1("YOUR-API-KEY")
+scala>  Await.result(api.ping, 10 seconds)
+res1: Either[io.skyfii.mandrill.model.Error,String] = Right("PONG!")

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ libraryDependencies += "io.skyfii" %% "skyfii-mandrill" % "0.0.2"
 ### Test your API key
 
 In an SBT console:
-
+```bash
 scala>  import scala.concurrent._
 scala>  import scala.concurrent.duration._
 scala>  import scala.concurrent.ExecutionContext.Implicits.global
@@ -29,3 +29,4 @@ scala>  import io.skyfii.mandrill.service._
 scala>  val api = new MandrillApiV1("YOUR-API-KEY")
 scala>  Await.result(api.ping, 10 seconds)
 res1: Either[io.skyfii.mandrill.model.Error,String] = Right("PONG!")
+```

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,6 @@ libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "1.2" withSources() withJavadoc(),
   "net.databinder.dispatch" %% "dispatch-core" % "0.11.2" withSources() withJavadoc(),
   "ch.qos.logback" % "logback-classic" % "1.1.2" withSources() withJavadoc(),
-
   "org.scalatest" %% "scalatest" % "2.2.1" % "test" withSources() withJavadoc()
 )
 

--- a/src/main/scala/io/skyfii/mandrill/service/MandrillApiV1.scala
+++ b/src/main/scala/io/skyfii/mandrill/service/MandrillApiV1.scala
@@ -7,14 +7,15 @@ import io.skyfii.mandrill.support.MandrillCodecs._
 import argonaut.Argonaut._
 import argonaut._
 import com.ning.http.client.Response
-import dispatch.Defaults._
 import dispatch._
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-class MandrillApiV1(apiKey: String, apiUrlPrefix: String = "https://mandrillapp.com/api/1.0") {
+class MandrillApiV1(apiKey: String,
+                    apiUrlPrefix: String = "https://mandrillapp.com/api/1.0")
+                   (implicit ex:ExecutionContext) {
 
   type AsyncResponse[T] = Future[Either[Error, T]]
 
@@ -72,7 +73,10 @@ class MandrillApiV1(apiKey: String, apiUrlPrefix: String = "https://mandrillapp.
   /**
    * Add a new sub account to the main account
    */
-  def subAccountAdd(id: String, name: Option[String] = None, notes: Option[String] = None, quota: Option[Int] = None): AsyncResponse[SubAccountResponse] = {
+  def subAccountAdd(id: String,
+                    name: Option[String] = None,
+                    notes: Option[String] = None,
+                    quota: Option[Int] = None): AsyncResponse[SubAccountResponse] = {
     val subAccountAddRequest = SubAccountRequest(key = apiKey,
       id = id,
       name = name,

--- a/src/test/scala/io/skyfii/mandrill/service/MandrillApiV1Test.scala
+++ b/src/test/scala/io/skyfii/mandrill/service/MandrillApiV1Test.scala
@@ -20,131 +20,129 @@ class MandrillApiV1Test extends FunSpec with ShouldMatchers {
     def wait[T](f: Future[T]): T = Await.result(f, 30 seconds)
   }
 
-  ignore("run these when Mandrill publishes API changes...") {
-    describe("all api services") {
+  describe("all api services") {
 
-      describe("#ping") {
-        it("pings and pongs") {
-          new Fixtures {
-            val response = wait(api.ping)
-            response should be(Right("\"PONG!\""))
-          }
+    describe("#ping") {
+      it("pings and pongs") {
+        new Fixtures {
+          val response = wait(api.ping)
+          response should be(Right("\"PONG!\""))
         }
-        it("fails with bad API key") {
-          new Fixtures {
-            val badApi = new MandrillApiV1("badKey")
-            val response = wait(badApi.ping)
-            response.isLeft shouldBe true
-          }
+      }
+      it("fails with bad API key") {
+        new Fixtures {
+          val badApi = new MandrillApiV1("badKey")
+          val response = wait(badApi.ping)
+          response.isLeft shouldBe true
+        }
+      }
+    }
+
+    describe("#usersInfo") {
+      it("retrieves and decodes user info") {
+        new Fixtures {
+          val response = wait(api.usersInfo)
+          response.isRight shouldBe true
+        }
+      }
+    }
+
+    describe("#messagesSend") {
+      it("sends nothing for bad arguments") {
+        new Fixtures {
+          // Mandrill's API for test users might be dumbed down -it allows obviously fake
+          // recipient addresses and sending to 0 recipients. We ignore those cases.
+
+          val message = new Message("<p>test html content</p>", None, "test", "bad from address",
+            None, Vector(new Recipient("user1@skyfii.com", None, ToType.cc)))
+          val sendResponse = wait(api.messagesSend(message, sendAsynchronously = false, None, None))
+
+          sendResponse.isLeft shouldBe true
+          sendResponse.left.get.name === "ValidationError"
         }
       }
 
-      describe("#usersInfo") {
-        it("retrieves and decodes user info") {
-          new Fixtures {
-            val response = wait(api.usersInfo)
-            response.isRight shouldBe true
-          }
+      it("sends a message and decodes the response") {
+        new Fixtures {
+          val recipients = Vector(new Recipient("user1@skyfii.com", Some("daniel"), ToType.to))
+          val message = new Message("<p>test html content</p>", None, "test", "noreply@skyfii.com", None, recipients)
+          val sendResponse = wait(api.messagesSend(message, sendAsynchronously = false, None, None))
+          val recipientResponses = sendResponse.right.get
+          recipientResponses.length === 1
+          recipientResponses.head.email === "user1@skyfii.com"
+          recipientResponses.head.status === "sent"
         }
       }
 
-      describe("#messagesSend") {
-        it("sends nothing for bad arguments") {
-          new Fixtures {
-            // Mandrill's API for test users might be dumbed down -it allows obviously fake
-            // recipient addresses and sending to 0 recipients. We ignore those cases.
+      it("sends many messages and decodes responses") {
+        new Fixtures {
+          val emails = (1 to 50) map (n => s"user$n@skyfii.com") toSet
+          val recipients = emails map (email => new Recipient(email, None, ToType.to)) toVector
 
-            val message = new Message("<p>test html content</p>", None, "test", "bad from address",
-              None, Vector(new Recipient("user1@skyfii.com", None, ToType.cc)))
-            val sendResponse = wait(api.messagesSend(message, sendAsynchronously = false, None, None))
+          val message = new Message("<p>test html content</p>", None, "test many", "noreply@skyfii.com", None, recipients)
+          val sendResponse = wait(api.messagesSend(message, sendAsynchronously = true, None, None))
+          val recipientResponses = sendResponse.right.get
+          recipientResponses.length === 50
+          (recipientResponses map (_.email) toSet) === emails
 
-            sendResponse.isLeft shouldBe true
-            sendResponse.left.get.name === "ValidationError"
-          }
+          every(recipientResponses map (_.status)) shouldBe "queued"
         }
+      }
+    }
 
-        it("sends a message and decodes the response") {
-          new Fixtures {
-            val recipients = Vector(new Recipient("user1@skyfii.com", Some("daniel"), ToType.to))
-            val message = new Message("<p>test html content</p>", None, "test", "noreply@skyfii.com", None, recipients)
-            val sendResponse = wait(api.messagesSend(message, sendAsynchronously = false, None, None))
-            val recipientResponses = sendResponse.right.get
-            recipientResponses.length === 1
-            recipientResponses.head.email === "user1@skyfii.com"
-            recipientResponses.head.status === "sent"
-          }
-        }
-
-        it("sends many messages and decodes responses") {
-          new Fixtures {
-            val emails = (1 to 50) map (n => s"user$n@skyfii.com") toSet
-            val recipients = emails map (email => new Recipient(email, None, ToType.to)) toVector
-
-            val message = new Message("<p>test html content</p>", None, "test many", "noreply@skyfii.com", None, recipients)
-            val sendResponse = wait(api.messagesSend(message, sendAsynchronously = true, None, None))
-            val recipientResponses = sendResponse.right.get
-            recipientResponses.length === 50
-            (recipientResponses map (_.email) toSet) === emails
-
-            every(recipientResponses map (_.status)) shouldBe "queued"
-          }
+    describe("#subAccountInfo") {
+      it("fails when sub account doesn't exist") {
+        new Fixtures {
+          val id = UUID.randomUUID().toString
+          val response = wait(api.subAccountInfo(id))
+          response.isLeft shouldBe true
         }
       }
 
-      describe("#subAccountInfo") {
-        it("fails when sub account doesn't exist") {
-          new Fixtures {
-            val id = UUID.randomUUID().toString
-            val response = wait(api.subAccountInfo(id))
-            response.isLeft shouldBe true
-          }
-        }
+      it("retrieves and decodes sub account info") {
+        new Fixtures {
+          val id = UUID.randomUUID().toString
+          val response = wait(api.subAccountAdd(id, Some("Test")))
+          response.isRight shouldBe true
 
-        it("retrieves and decodes sub account info") {
-          new Fixtures {
-            val id = UUID.randomUUID().toString
-            val response = wait(api.subAccountAdd(id, Some("Test")))
-            response.isRight shouldBe true
-
-            val responseInfo = wait(api.subAccountInfo(id))
-            responseInfo.isRight shouldBe true
-          }
+          val responseInfo = wait(api.subAccountInfo(id))
+          responseInfo.isRight shouldBe true
         }
       }
+    }
 
-      describe("#subAccountAdd") {
-        it("adds sub account and decodes the response") {
-          new Fixtures {
-            val id = UUID.randomUUID().toString
-            val response = wait(api.subAccountAdd(id, Some("Test")))
-            response.isRight shouldBe true
-          }
+    describe("#subAccountAdd") {
+      it("adds sub account and decodes the response") {
+        new Fixtures {
+          val id = UUID.randomUUID().toString
+          val response = wait(api.subAccountAdd(id, Some("Test")))
+          response.isRight shouldBe true
         }
       }
+    }
 
-      describe("#subAccountPause") {
-        it("pauses sub account and decodes the response") {
-          new Fixtures {
-            val id = UUID.randomUUID().toString
-            val response = wait(api.subAccountAdd(id, Some("Test")))
-            response.isRight shouldBe true
-            val pauseResponse = wait(api.subAccountPause(id))
-            pauseResponse.isRight shouldBe true
-          }
+    describe("#subAccountPause") {
+      it("pauses sub account and decodes the response") {
+        new Fixtures {
+          val id = UUID.randomUUID().toString
+          val response = wait(api.subAccountAdd(id, Some("Test")))
+          response.isRight shouldBe true
+          val pauseResponse = wait(api.subAccountPause(id))
+          pauseResponse.isRight shouldBe true
         }
       }
+    }
 
-      describe("#subAccountResume") {
-        it("resumes sub account and decodes the response") {
-          new Fixtures {
-            val id = UUID.randomUUID().toString
-            val response = wait(api.subAccountAdd(id, Some("Test")))
-            response.isRight shouldBe true
-            val pauseResponse = wait(api.subAccountPause(id))
-            pauseResponse.isRight shouldBe true
-            val resumeResponse = wait(api.subAccountResume(id))
-            resumeResponse.isRight shouldBe true
-          }
+    describe("#subAccountResume") {
+      it("resumes sub account and decodes the response") {
+        new Fixtures {
+          val id = UUID.randomUUID().toString
+          val response = wait(api.subAccountAdd(id, Some("Test")))
+          response.isRight shouldBe true
+          val pauseResponse = wait(api.subAccountPause(id))
+          pauseResponse.isRight shouldBe true
+          val resumeResponse = wait(api.subAccountResume(id))
+          resumeResponse.isRight shouldBe true
         }
       }
     }

--- a/src/test/scala/io/skyfii/mandrill/service/MandrillApiV1Test.scala
+++ b/src/test/scala/io/skyfii/mandrill/service/MandrillApiV1Test.scala
@@ -12,6 +12,7 @@ import scala.concurrent.{Await, Future}
 class MandrillApiV1Test extends FunSpec with ShouldMatchers {
 
   trait Fixtures {
+    implicit val ec = scala.concurrent.ExecutionContext.global
     val time = new DateTime(2015, 4, 1, 0, 0)
     val testKey = "add-your-key-here"
     val api = new MandrillApiV1(testKey)


### PR DESCRIPTION
we were tied to the global context before, which restricts end users.
also add some getting started doco.
I disabled the ignore for the sbt tests, but users need to supply an api key for running tests.
